### PR TITLE
Add `repository` to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "check markup for unclosed tags",
   "bin": "bin/index.js",
   "main": "lib/index.js",
+  "repository": "sveisvei/unclosed-markup",
   "scripts": {
     "test": "ava test/test.js && npm run lint",
     "lint": "eslint ."


### PR DESCRIPTION
Warning when running npm without this present, and makes the link on npmjs.com work.
